### PR TITLE
Fix Leaderboard link

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -125,12 +125,12 @@ project = Project(
     <h2>URLTeam 2
         <span class="links">
             <a href="http://urlte.am/">Website</a> &middot;
-            <a href="http://%s/">Leaderboard</a> &middot;
+            <a href="%s://%s/">Leaderboard</a> &middot;
             <a href="https://www.archiveteam.org/index.php?title=URLTeam">Wiki</a>
         </span>
     </h2>
     <p>The Terror of Tiny Town</p>
-    """ % (TRACKER_HOST)
+    """ % (SCHEME, TRACKER_HOST)
 )
 
 


### PR DESCRIPTION
Hello,

I was having HTTP 400's when clicking on the "leaderboard" link on the project page :

![link](https://user-images.githubusercontent.com/6537689/56076821-7e4e7900-5dd5-11e9-98f2-e59e7524baea.png)

![400](https://user-images.githubusercontent.com/6537689/55627112-b0e0ec00-57ad-11e9-9f55-13713176d8b9.png)

I changed the scheme of the link and it looks like that fixed it on my machine but someone please have a look because it's been literal years since i've touched Python.

Thanks,
Morgan