### PR TITLE
Make docker little lighter - python:3.4-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.4
+FROM python:3.4-alpine
 ARG repo=https://github.com/ArchiveTeam/terroroftinytown-client-grab
 ARG branch=master
 ENV LC_ALL=C.UTF-8
-RUN apt update \
- && apt install -y --no-install-recommends git-core \
+RUN apk update \
+ && apk add --no-cache git \
  && pip install --upgrade seesaw requests \
  && git clone "${repo}" grab \
  && cd grab \


### PR DESCRIPTION
There are a lot of unneeded software in provided docker image. Migrating to python:3.4-alpine will results in reduced docker image size from ~950MB to ~105 MB without losing functionality.

Image built on this patch is working, at least for me.