### PR TITLE
(bugfix) pin docker base image to python3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.8-alpine
 WORKDIR /grab
 COPY . /grab
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
### Issue:
**Seesaw dependency has problems with Python 3.10**, which as of right now will be installed when using python:3-alpine as base image.

### Solution:
Python 3.9 seems to work fine as well, but due to the age of the project **I opted for pinning to Python 3.8** to be on the safe side.

Open for any suggestions / comments.